### PR TITLE
Fixes typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ func pieChartView(_ pieChartView: AMPieChartView, didDeSelectSection section: In
 @IBInspectable public var centerLabelText: String = ""
 public var animationDuration: CFTimeInterval = 0.4
 public var selectedAnimationDuration: CFTimeInterval = 0.3
-public var centerLabelAttribetedText: NSAttributedString? = nil
+public var centerLabelAttributedText: NSAttributedString? = nil
 ```
 
 ### AMRadarChartView

--- a/Source/AMPieChartView.swift
+++ b/Source/AMPieChartView.swift
@@ -102,9 +102,9 @@ public class AMPieChartView: AMChartView {
     weak public var delegate: AMPieChartViewDelegate?
     public var animationDuration: CFTimeInterval = 0.4
     public var selectedAnimationDuration: CFTimeInterval = 0.3
-    public var centerLabelAttribetedText: NSAttributedString? = nil {
+    public var centerLabelAttributedText: NSAttributedString? = nil {
         didSet {
-            centerLabel.attributedText = centerLabelAttribetedText
+            centerLabel.attributedText = centerLabelAttributedText
         }
     }
     
@@ -365,3 +365,4 @@ public class AMPieChartView: AMChartView {
         reloadData()
     }
 }
+


### PR DESCRIPTION
I saw that this typo was also happening in the property name, not just the ReadMe, so it could be confusing.